### PR TITLE
Remove deprecated version of dev dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tmp/
 typings/
 .idea
 .cloud
+/.project

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   },
   "devDependencies": {
     "nativescript-dev-typescript": "~0.5.0",
-    "nativescript-dev-android-snapshot": "^0.*.*",
     "typescript": "~2.2.1",
     "tslint": "^5.4.3"
   }


### PR DESCRIPTION
It can be added once new version is out and compatible with cloud
builds.