### PR TITLE
Change action bar layout to have action-bar-title

### DIFF
--- a/home/home-page.xml
+++ b/home/home-page.xml
@@ -2,7 +2,8 @@
     navigatingTo="onNavigatingTo" 
     xmlns="http://www.nativescript.org/tns.xsd">
     
-    <ActionBar class="action-bar" title="Home">
+    <ActionBar class="action-bar">
+        <Label class="action-bar-title" text="Home"></Label>
     </ActionBar>
 
     <GridLayout>


### PR DESCRIPTION
Change action bar layout to use the same layout as the other templates. In this way the page title will be always center. Otherwise once will be center, another time - left